### PR TITLE
Fix SDL3 setup and migrate to new APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ add_executable(flint-and-timber src/main.cpp)
 
 target_include_directories(flint-and-timber PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/bgfx.cmake/bgfx/include>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/external/SDL/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/SDL/include>
 )
 
 target_link_libraries(flint-and-timber
     PRIVATE
-    SDL3
+    SDL3-shared
     bgfx
 )
 


### PR DESCRIPTION
This change fixes the build failure caused by an incorrect SDL setup. The project was using SDL3 but the source code was still using SDL2-style includes and APIs.

- Updated `src/main.cpp` to use SDL3 headers and the new property-based API for getting native window handles.
- Updated event handling to use the new SDL3 event names and structures.
- Corrected the `CMakeLists.txt` to properly include the SDL3 source directory.