### PR TITLE
feat: Render a 3D test triangle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,14 @@ add_subdirectory(external/bgfx.cmake)
 
 add_executable(flint-and-timber src/main.cpp)
 
+bgfx_shader_library(shaders
+    SHADERS
+        src/shaders/v_simple.sc
+        src/shaders/f_simple.sc
+    TYPE "all"
+    OUTPUT_DIR "src/shaders/autogen"
+)
+
 target_include_directories(flint-and-timber PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/bgfx.cmake/bgfx/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/SDL/include>
@@ -18,6 +26,7 @@ target_link_libraries(flint-and-timber
     PRIVATE
     SDL3-shared
     bgfx
+    shaders
 )
 
 if(WIN32)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,13 +4,52 @@
 #include <SDL3/SDL_properties.h>
 #include <bgfx/bgfx.h>
 #include <bgfx/platform.h>
+#include <bx/math.h>
+#include <bgfx/embedded_shader.h>
+
+#include "v_simple.sc.h"
+#include "f_simple.sc.h"
 
 #include <iostream>
+
 
 namespace flint_and_timber {
 
 #define FLINT_AND_TIMBER_WINDOW_WIDTH 1280
 #define FLINT_AND_TIMBER_WINDOW_HEIGHT 720
+
+struct PosColorVertex {
+    float x, y, z;
+    uint32_t abgr;
+
+    static void init() {
+        ms_layout
+            .begin()
+            .add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float)
+            .add(bgfx::Attrib::Color0, 4, bgfx::AttribType::Uint8, true, true)
+            .end();
+    };
+
+    static bgfx::VertexLayout ms_layout;
+};
+
+bgfx::VertexLayout PosColorVertex::ms_layout;
+
+static PosColorVertex s_triangleVertices[] = {
+    {-0.5f, -0.5f, 0.0f, 0xff0000ff}, // Bottom-left, Red
+    { 0.5f, -0.5f, 0.0f, 0xff00ff00}, // Bottom-right, Green
+    { 0.0f,  0.5f, 0.0f, 0xffff0000}, // Top-center, Blue
+};
+
+static const uint16_t s_triangleIndices[] = {
+    0, 1, 2,
+};
+
+static const bgfx::EmbeddedShader s_embeddedShaders[] = {
+    BGFX_EMBEDDED_SHADER(v_simple),
+    BGFX_EMBEDDED_SHADER(f_simple),
+    BGFX_EMBEDDED_SHADER_END()
+};
 
 void run() {
     SDL_Init(SDL_INIT_VIDEO);
@@ -48,11 +87,31 @@ void run() {
     bgfx_init.resolution.height = FLINT_AND_TIMBER_WINDOW_HEIGHT;
     bgfx_init.resolution.reset = BGFX_RESET_VSYNC;
     bgfx_init.platformData = pd;
+    bgfx_init.rendererType = bgfx::RendererType::OpenGL;
+
 
     if (!bgfx::init(bgfx_init)) {
         std::cerr << "Failed to initialize bgfx" << std::endl;
         return;
     }
+
+    PosColorVertex::init();
+
+    bgfx::VertexBufferHandle vbh = bgfx::createVertexBuffer(
+        bgfx::makeRef(s_triangleVertices, sizeof(s_triangleVertices)),
+        PosColorVertex::ms_layout
+    );
+
+    bgfx::IndexBufferHandle ibh = bgfx::createIndexBuffer(
+        bgfx::makeRef(s_triangleIndices, sizeof(s_triangleIndices))
+    );
+
+    bgfx::RendererType::Enum type = bgfx::getRendererType();
+    bgfx::ProgramHandle program = bgfx::createProgram(
+        bgfx::createEmbeddedShader(s_embeddedShaders, type, "v_simple"),
+        bgfx::createEmbeddedShader(s_embeddedShaders, type, "f_simple"),
+        true
+    );
 
     bgfx::setViewClear(0, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, 0x6495EDFF, 1.0f, 0);
 
@@ -68,13 +127,34 @@ void run() {
                 }
             } else if (event.type == SDL_EVENT_WINDOW_RESIZED) {
                 bgfx::reset(event.window.data1, event.window.data2, BGFX_RESET_VSYNC);
-                bgfx::setViewRect(0, 0, 0, bgfx::BackbufferRatio::Equal);
             }
         }
 
+        const bx::Vec3 at = {0.0f, 0.0f, 0.0f};
+        const bx::Vec3 eye = {0.0f, 0.0f, -2.0f};
+
+        float view[16];
+        bx::mtxLookAt(view, eye, at);
+
+        float proj[16];
+        bx::mtxProj(proj, 60.0f, float(FLINT_AND_TIMBER_WINDOW_WIDTH) / float(FLINT_AND_TIMBER_WINDOW_HEIGHT), 0.1f, 100.0f, bgfx::getCaps()->homogeneousDepth);
+
+        bgfx::setViewRect(0, 0, 0, FLINT_AND_TIMBER_WINDOW_WIDTH, FLINT_AND_TIMBER_WINDOW_HEIGHT);
+        bgfx::setViewTransform(0, view, proj);
+
         bgfx::touch(0);
+
+        bgfx::setVertexBuffer(0, vbh);
+        bgfx::setIndexBuffer(ibh);
+        bgfx::setState(BGFX_STATE_DEFAULT);
+        bgfx::submit(0, program);
+
         bgfx::frame();
     }
+
+    bgfx::destroy(ibh);
+    bgfx::destroy(vbh);
+    bgfx::destroy(program);
 
     bgfx::shutdown();
     SDL_DestroyWindow(window);

--- a/src/shaders/f_simple.sc
+++ b/src/shaders/f_simple.sc
@@ -1,0 +1,7 @@
+$input v_color0
+#include <bgfx_shader.sh>
+
+void main()
+{
+    gl_FragColor = v_color0;
+}

--- a/src/shaders/v_simple.sc
+++ b/src/shaders/v_simple.sc
@@ -1,0 +1,10 @@
+$input a_position, a_color0
+$output v_color0
+
+#include <bgfx_shader.sh>
+
+void main()
+{
+    gl_Position = mul(u_modelViewProj, vec4(a_position, 1.0));
+    v_color0 = a_color0;
+}


### PR DESCRIPTION
This commit introduces the necessary code to render a single, colored 3D triangle using bgfx.

Changes include:
- Addition of simple vertex and fragment shaders.
- Configuration of `CMakeLists.txt` to compile and embed the shaders.
- Implementation of rendering logic in `src/main.cpp`, including vertex layout, buffer creation, shader program setup, and the main render loop submission.