### PR TITLE
Fix(cmake): Use add_subdirectory for DiligentEngine submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,9 @@ jobs:
         cd build
         cmake ..
         cmake --build . --config Release
+
+    - name: Upload Executable Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: YourAppName-Linux
+        path: build/YourAppName

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ target_link_libraries(YourAppName PRIVATE
     Diligent-Common
     Diligent-GraphicsTools
     Diligent-TextureLoader
-    Diligent-FX
-    Diligent-NativeApp-SDL
+    DiligentFX
+    Diligent-NativeAppBase
     ${ENGINE_LIBRARIES}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # The second argument specifies the build directory for SDL.
 add_subdirectory(external/SDL build_sdl)
 
+# Disable building the DiligentEngine samples as they are not needed and cause build errors.
+set(DILIGENT_BUILD_SAMPLES OFF CACHE BOOL "Build DiligentSamples module" FORCE)
+
 # Add the DiligentEngine submodule directory to the CMake build.
 add_subdirectory(external/DiligentEngine)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # The second argument specifies the build directory for SDL.
 add_subdirectory(external/SDL build_sdl)
 
-# Add Diligent Engine using FetchContent
-include(FetchContent)
-FetchContent_Declare(
-    DiligentEngine
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/DiligentEngine"
-)
-FetchContent_MakeAvailable(DiligentEngine)
+# Add the DiligentEngine submodule directory to the CMake build.
+add_subdirectory(external/DiligentEngine)
 
 
 # Create the executable for our project from main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,14 +37,18 @@ target_include_directories(YourAppName PRIVATE
 # CMake knows about the "SDL3::SDL3" target because we used add_subdirectory().
 target_link_libraries(YourAppName PRIVATE SDL3::SDL3)
 
+# Get the list of supported engine backend libraries (e.g. Diligent-GraphicsEngineD3D11-shared)
+get_supported_backends(ENGINE_LIBRARIES)
+
 # Link against Diligent Engine libraries
 target_link_libraries(YourAppName PRIVATE
     Diligent-BuildSettings
-    Diligent-Core
-    Diligent-Graphics
-    Diligent-Tools
+    Diligent-Common
+    Diligent-GraphicsTools
+    Diligent-TextureLoader
     Diligent-FX
     Diligent-NativeApp-SDL
+    ${ENGINE_LIBRARIES}
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,11 @@ target_link_libraries(YourAppName PRIVATE SDL3::SDL3)
 # Link against Diligent Engine libraries
 target_link_libraries(YourAppName PRIVATE
     Diligent-BuildSettings
-    Diligent::Core
-    Diligent::Graphics
-    Diligent::Tools
-    Diligent::FX
-    Diligent::NativeApp-SDL
+    Diligent-Core
+    Diligent-Graphics
+    Diligent-Tools
+    Diligent-FX
+    Diligent-NativeApp-SDL
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(YourAppName PRIVATE SDL3::SDL3)
 
 # Link against Diligent Engine libraries
 target_link_libraries(YourAppName PRIVATE
-    Diligent::BuildSettings
+    Diligent-BuildSettings
     Diligent::Core
     Diligent::Graphics
     Diligent::Tools


### PR DESCRIPTION
Replaced the FetchContent block with a direct call to add_subdirectory for the DiligentEngine submodule.

This is a more standard and robust way to include a git submodule in a CMake project, and it should resolve the issue where the Diligent::BuildSettings target was not being found during the build configuration.