### PR TITLE
Rename project to Flint & Timber

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: YourAppName-Linux
-        path: build/YourAppName
+        name: flint-and-timber-Linux
+        path: build/flint-and-timber

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # Define the project name, version, and language
-project(DiligentApp VERSION 1.0 LANGUAGES CXX)
+project(FlintAndTimber VERSION 1.0 LANGUAGES CXX)
 
 # Set the C++ standard to C++17
 set(CMAKE_CXX_STANDARD 17)
@@ -22,10 +22,10 @@ add_subdirectory(external/DiligentEngine)
 
 
 # Create the executable for our project from main.cpp
-add_executable(YourAppName src/main.cpp src/DiligentApp.cpp)
+add_executable(flint-and-timber src/main.cpp src/FlintAndTimberApp.cpp)
 
 # Add include directories for Diligent Engine
-target_include_directories(YourAppName PRIVATE
+target_include_directories(flint-and-timber PRIVATE
     "external/DiligentEngine"
     "external/DiligentEngine/DiligentCore/include"
     "external/DiligentEngine/DiligentCore/Common/interface"
@@ -38,13 +38,13 @@ target_include_directories(YourAppName PRIVATE
 
 # Link our application against the SDL3 library.
 # CMake knows about the "SDL3::SDL3" target because we used add_subdirectory().
-target_link_libraries(YourAppName PRIVATE SDL3::SDL3)
+target_link_libraries(flint-and-timber PRIVATE SDL3::SDL3)
 
 # Get the list of supported engine backend libraries (e.g. Diligent-GraphicsEngineD3D11-shared)
 get_supported_backends(ENGINE_LIBRARIES)
 
 # Link against Diligent Engine libraries
-target_link_libraries(YourAppName PRIVATE
+target_link_libraries(flint-and-timber PRIVATE
     Diligent-BuildSettings
     Diligent-Common
     Diligent-GraphicsTools
@@ -59,12 +59,12 @@ target_link_libraries(YourAppName PRIVATE
 
 # For Windows, we want a windowed application, not a console one.
 if(WIN32)
-    set_target_properties(YourAppName PROPERTIES WIN32_EXECUTABLE ON)
+    set_target_properties(flint-and-timber PROPERTIES WIN32_EXECUTABLE ON)
 endif()
 
 # For macOS, we need to create an application bundle to handle events correctly.
 if(APPLE)
-    set_target_properties(YourAppName PROPERTIES MACOSX_BUNDLE ON)
+    set_target_properties(flint-and-timber PROPERTIES MACOSX_BUNDLE ON)
     
     # This helps locate the bundle resources correctly when running from the build dir
     set(CMAKE_MACOSX_RPATH 1)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# flint-and-timber
+# Flint & Timber

--- a/src/FlintAndTimberApp.cpp
+++ b/src/FlintAndTimberApp.cpp
@@ -1,4 +1,4 @@
-#include "DiligentApp.hpp"
+#include "FlintAndTimberApp.hpp"
 
 #include <SDL3/SDL_properties.h>
 
@@ -78,18 +78,18 @@ void main(in  PSInput  PSIn,
 }
 )";
 
-DiligentApp::DiligentApp(SDL_Window* window)
+FlintAndTimberApp::FlintAndTimberApp(SDL_Window* window)
 {
     InitializeDiligentEngine(window);
     CreatePipelineState();
 }
 
-DiligentApp::~DiligentApp()
+FlintAndTimberApp::~FlintAndTimberApp()
 {
     m_pImmediateContext->Flush();
 }
 
-void DiligentApp::InitializeDiligentEngine(SDL_Window* window)
+void FlintAndTimberApp::InitializeDiligentEngine(SDL_Window* window)
 {
     Diligent::SwapChainDesc SCDesc;
     SDL_PropertiesID props = SDL_GetWindowProperties(window);
@@ -130,10 +130,10 @@ void DiligentApp::InitializeDiligentEngine(SDL_Window* window)
 #endif
 }
 
-void DiligentApp::CreatePipelineState()
+void FlintAndTimberApp::CreatePipelineState()
 {
     Diligent::GraphicsPipelineStateCreateInfo PSOCreateInfo;
-    PSOCreateInfo.PSODesc.Name = "Simple triangle PSO";
+    PSOCreateInfo.PSODesc.Name = "Flint & Timber PSO";
     PSOCreateInfo.PSODesc.PipelineType = Diligent::PIPELINE_TYPE_GRAPHICS;
     PSOCreateInfo.GraphicsPipeline.NumRenderTargets = 1;
     PSOCreateInfo.GraphicsPipeline.RTVFormats[0] = m_pSwapChain->GetDesc().ColorBufferFormat;
@@ -170,7 +170,7 @@ void DiligentApp::CreatePipelineState()
     m_pDevice->CreateGraphicsPipelineState(PSOCreateInfo, &m_pPSO);
 }
 
-void DiligentApp::Render()
+void FlintAndTimberApp::Render()
 {
     auto* pRTV = m_pSwapChain->GetCurrentBackBufferRTV();
     auto* pDSV = m_pSwapChain->GetDepthBufferDSV();

--- a/src/FlintAndTimberApp.hpp
+++ b/src/FlintAndTimberApp.hpp
@@ -8,10 +8,10 @@
 #include "SwapChain.h"
 #include "PipelineState.h"
 
-class DiligentApp {
+class FlintAndTimberApp {
 public:
-    DiligentApp(SDL_Window* window);
-    ~DiligentApp();
+    FlintAndTimberApp(SDL_Window* window);
+    ~FlintAndTimberApp();
 
     void Render();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include "DiligentApp.hpp"
+#include "FlintAndTimberApp.hpp"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 #include <iostream>
@@ -12,7 +12,7 @@ int main(int argc, char* argv[])
     }
 
     SDL_Window* window = SDL_CreateWindow(
-        "Diligent Engine Triangle with SDL3",
+        "Flint & Timber",
         800,
         600,
         SDL_WINDOW_RESIZABLE);
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        DiligentApp app(window);
+        FlintAndTimberApp app(window);
 
         bool is_running = true;
         SDL_Event event;


### PR DESCRIPTION
This commit renames the project from 'DiligentApp' and 'YourAppName' to 'Flint & Timber'.

Changes include:
- Updating the project name and executable name in CMakeLists.txt.
- Changing the main window title.
- Renaming the main application class and files to FlintAndTimberApp.
- Updating the artifact name in the GitHub Actions workflow.
- Adjusting the project title in README.md.