### PR TITLE
The GitHub Actions workflow was only uploading the bare executable, c…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install dependencies
       run: >
-        dnf install -y mesa-libGL-devel libxcb libxcb-devel libX11-xcb libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel libXext-devel libxkbcommon libxkbcommon-devel libxkbcommon-x11-devel mesa-vulkan-drivers wayland-protocols-devel wayland-devel zip
+        dnf install -y mesa-libGL-devel libxcb libxcb-devel libX11-xcb libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel libXext-devel libxkbcommon libxkbcommon-devel libxkbcommon-x11-devel mesa-vulkan-drivers wayland-protocols-devel wayland-devel
 
     - name: Configure CMake
       run: cmake --preset release
@@ -29,14 +29,10 @@ jobs:
     - name: Build
       run: cmake --build --preset release
 
-    - name: Package Artifact
-      run: |
-        mkdir -p dist
-        cp build/release/flint-and-timber dist/
-        cp build/release/libwebgpu_dawn.so dist/
-        (cd dist && zip -r ../flint-and-timber-Linux.zip .)
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v4
       with:
         name: flint-and-timber-Linux
-        path: flint-and-timber-Linux.zip
+        path: |
+          build/release/flint-and-timber
+          build/release/libwebgpu_dawn.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install dependencies
       run: >
-        dnf install -y mesa-libGL-devel libxcb libxcb-devel libX11-xcb libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel libXext-devel libxkbcommon libxkbcommon-devel libxkbcommon-x11-devel mesa-vulkan-drivers wayland-protocols-devel wayland-devel
+        dnf install -y mesa-libGL-devel libxcb libxcb-devel libX11-xcb libXcursor-devel libXrandr-devel libXinerama-devel libXi-devel libXext-devel libxkbcommon libxkbcommon-devel libxkbcommon-x11-devel mesa-vulkan-drivers wayland-protocols-devel wayland-devel zip
 
     - name: Configure CMake
       run: cmake --preset release
@@ -34,9 +34,9 @@ jobs:
         mkdir -p dist
         cp build/release/flint-and-timber dist/
         cp build/release/libwebgpu_dawn.so dist/
-        tar -czvf flint-and-timber-Linux.tar.gz -C dist .
+        (cd dist && zip -r ../flint-and-timber-Linux.zip .)
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v4
       with:
         name: flint-and-timber-Linux
-        path: flint-and-timber-Linux.tar.gz
+        path: flint-and-timber-Linux.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,14 @@ jobs:
     - name: Build
       run: cmake --build --preset release
 
+    - name: Package Artifact
+      run: |
+        mkdir -p dist
+        cp build/release/flint-and-timber dist/
+        cp build/release/libwebgpu_dawn.so dist/
+        tar -czvf flint-and-timber-Linux.tar.gz -C dist .
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v4
       with:
         name: flint-and-timber-Linux
-        path: build/release/flint-and-timber
+        path: flint-and-timber-Linux.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,16 @@ target_link_libraries(${TARGET_NAME} PRIVATE
     sdl3webgpu
 )
 
+# Set RPATH for Linux to find shared libraries in the executable's directory
+if(UNIX AND NOT APPLE)
+    set_target_properties(${TARGET_NAME} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+    set_target_properties(${TARGET_NAME} PROPERTIES
+        INSTALL_RPATH "$ORIGIN"
+    )
+endif()
+
 # Include directories
 target_include_directories(${TARGET_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/webgpu/include


### PR DESCRIPTION
…ausing a "shared library not found" error at runtime.

This change modifies the workflow to:
1. Create a `dist` directory.
2. Copy the `flint-and-timber` executable and the `libwebgpu_dawn.so` shared library into the `dist` directory.
3. Create a compressed `tar.gz` archive of the `dist` directory.
4. Upload the `tar.gz` archive as the build artifact instead of the bare executable.

This ensures that the release artifact is a self-contained, minimal bundle that includes all necessary files to run the game.