### PR TITLE
feat: Implement rendering for a single 16x32x16 chunk

### DIFF
--- a/src/flint/app.cpp
+++ b/src/flint/app.cpp
@@ -456,14 +456,14 @@ fn fs_main(@location(0) color: vec3<f32>) -> @location(0) vec4<f32> {
         std::cout << "Setting up 3D components..." << std::endl;
 
         // Initialize camera
-        m_camera.setPosition(glm::vec3(2.0f, 2.0f, 3.0f));             // Position camera to see cube at angle
-        m_camera.setTarget(glm::vec3(0.0f, 0.0f, 0.0f));               // Look at origin
-        m_camera.setPerspective(45.0f, 800.0f / 600.0f, 0.1f, 100.0f); // FOV, aspect ratio, near, far
+        m_camera.setPosition(glm::vec3(8.0f, 40.0f, 24.0f));
+        m_camera.setTarget(glm::vec3(8.0f, 16.0f, 8.0f));
+        m_camera.setPerspective(45.0f, 800.0f / 600.0f, 0.1f, 100.0f);
 
-        // Initialize cube mesh
-        if (!m_cubeMesh.initialize(m_device))
+        // Initialize chunk
+        if (!m_chunk.initialize(m_device))
         {
-            std::cerr << "Failed to initialize cube mesh!" << std::endl;
+            std::cerr << "Failed to initialize chunk!" << std::endl;
             return false;
         }
 
@@ -669,8 +669,8 @@ fn fs_main(@location(0) color: vec3<f32>) -> @location(0) vec4<f32> {
             // Bind the uniform buffer (camera matrix)
             wgpuRenderPassEncoderSetBindGroup(renderPass, 0, m_bindGroup, 0, nullptr);
 
-            // Draw the cube using our mesh class
-            m_cubeMesh.render(renderPass);
+            // Draw the chunk using our chunk class
+            m_chunk.render(renderPass);
 
             wgpuRenderPassEncoderEnd(renderPass);
 

--- a/src/flint/app.hpp
+++ b/src/flint/app.hpp
@@ -6,6 +6,7 @@
 
 #include "math/camera.hpp"
 #include "graphics/mesh.hpp"
+#include "chunk.hpp"
 
 namespace flint
 {
@@ -37,7 +38,7 @@ namespace flint
         WGPURenderPipeline m_renderPipeline = nullptr;
 
         math::Camera m_camera;
-        graphics::CubeMesh m_cubeMesh;
+        Chunk m_chunk;
 
         WGPUBuffer m_uniformBuffer = nullptr;
         WGPUBindGroup m_bindGroup = nullptr;

--- a/src/flint/chunk.cpp
+++ b/src/flint/chunk.cpp
@@ -1,0 +1,228 @@
+#include "chunk.hpp"
+
+#include <iostream>
+
+namespace flint
+{
+    Chunk::Chunk()
+    {
+    }
+
+    Chunk::~Chunk()
+    {
+        cleanup();
+    }
+
+    bool Chunk::initialize(WGPUDevice device)
+    {
+        m_device = device;
+
+        generateChunkData();
+        generateMesh();
+
+        // Create vertex buffer
+        WGPUBufferDescriptor vertexBufferDesc = {};
+        vertexBufferDesc.size = m_vertices.size() * sizeof(graphics::Vertex);
+        vertexBufferDesc.usage = WGPUBufferUsage_Vertex | WGPUBufferUsage_CopyDst;
+        vertexBufferDesc.mappedAtCreation = false;
+
+        m_vertexBuffer = wgpuDeviceCreateBuffer(device, &vertexBufferDesc);
+        if (!m_vertexBuffer)
+        {
+            std::cerr << "Failed to create vertex buffer" << std::endl;
+            return false;
+        }
+
+        // Upload vertex data
+        wgpuQueueWriteBuffer(wgpuDeviceGetQueue(device), m_vertexBuffer, 0,
+                             m_vertices.data(), vertexBufferDesc.size);
+
+        // Create index buffer
+        WGPUBufferDescriptor indexBufferDesc = {};
+        indexBufferDesc.size = m_indices.size() * sizeof(uint16_t);
+        indexBufferDesc.usage = WGPUBufferUsage_Index | WGPUBufferUsage_CopyDst;
+        indexBufferDesc.mappedAtCreation = false;
+
+        m_indexBuffer = wgpuDeviceCreateBuffer(device, &indexBufferDesc);
+        if (!m_indexBuffer)
+        {
+            std::cerr << "Failed to create index buffer" << std::endl;
+            return false;
+        }
+
+        // Upload index data
+        wgpuQueueWriteBuffer(wgpuDeviceGetQueue(device), m_indexBuffer, 0,
+                             m_indices.data(), indexBufferDesc.size);
+
+        return true;
+    }
+
+    void Chunk::cleanup()
+    {
+        if (m_vertexBuffer)
+        {
+            wgpuBufferRelease(m_vertexBuffer);
+            m_vertexBuffer = nullptr;
+        }
+        if (m_indexBuffer)
+        {
+            wgpuBufferRelease(m_indexBuffer);
+            m_indexBuffer = nullptr;
+        }
+    }
+
+    void Chunk::render(WGPURenderPassEncoder renderPass) const
+    {
+        if (!m_vertexBuffer || !m_indexBuffer)
+            return;
+
+        // Bind buffers and draw
+        wgpuRenderPassEncoderSetVertexBuffer(renderPass, 0, m_vertexBuffer, 0, WGPU_WHOLE_SIZE);
+        wgpuRenderPassEncoderSetIndexBuffer(renderPass, m_indexBuffer, WGPUIndexFormat_Uint16, 0, WGPU_WHOLE_SIZE);
+        wgpuRenderPassEncoderDrawIndexed(renderPass, static_cast<uint32_t>(m_indices.size()), 1, 0, 0, 0);
+    }
+
+    void Chunk::generateChunkData()
+    {
+        for (int x = 0; x < CHUNK_WIDTH; ++x)
+        {
+            for (int z = 0; z < CHUNK_DEPTH; ++z)
+            {
+                for (int y = 0; y < CHUNK_HEIGHT; ++y)
+                {
+                    if (y == CHUNK_HEIGHT - 1)
+                    {
+                        m_blocks[x][y][z] = BlockType::Grass;
+                    }
+                    else if (y < CHUNK_HEIGHT - 1 && y > CHUNK_HEIGHT - 5)
+                    {
+                        m_blocks[x][y][z] = BlockType::Dirt;
+                    }
+                    else
+                    {
+                        m_blocks[x][y][z] = BlockType::Air;
+                    }
+                }
+            }
+        }
+    }
+
+    void Chunk::generateMesh()
+    {
+        m_vertices.clear();
+        m_indices.clear();
+
+        glm::vec3 dirtColor = {0.5f, 0.25f, 0.0f};
+        glm::vec3 grassColor = {0.0f, 1.0f, 0.0f};
+
+        for (int x = 0; x < CHUNK_WIDTH; ++x)
+        {
+            for (int y = 0; y < CHUNK_HEIGHT; ++y)
+            {
+                for (int z = 0; z < CHUNK_DEPTH; ++z)
+                {
+                    if (m_blocks[x][y][z] == BlockType::Air)
+                    {
+                        continue;
+                    }
+
+                    glm::vec3 color = (m_blocks[x][y][z] == BlockType::Grass) ? grassColor : dirtColor;
+                    glm::vec3 position = {(float)x, (float)y, (float)z};
+
+                    // Check each face
+                    // Front face
+                    if (z == CHUNK_DEPTH - 1 || m_blocks[x][y][z + 1] == BlockType::Air)
+                    {
+                        uint16_t baseIndex = m_vertices.size();
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, -0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, -0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, 0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, 0.5f, 0.5f)}, color});
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 1);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 3);
+                        m_indices.push_back(baseIndex);
+                    }
+                    // Back face
+                    if (z == 0 || m_blocks[x][y][z - 1] == BlockType::Air)
+                    {
+                        uint16_t baseIndex = m_vertices.size();
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, -0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, -0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, 0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, 0.5f, -0.5f)}, color});
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 1);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 3);
+                    }
+                    // Top face
+                    if (y == CHUNK_HEIGHT - 1 || m_blocks[x][y + 1][z] == BlockType::Air)
+                    {
+                        uint16_t baseIndex = m_vertices.size();
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, 0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, 0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, 0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, 0.5f, -0.5f)}, color});
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 1);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 3);
+                        m_indices.push_back(baseIndex);
+                    }
+                    // Bottom face
+                    if (y == 0 || m_blocks[x][y - 1][z] == BlockType::Air)
+                    {
+                        uint16_t baseIndex = m_vertices.size();
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, -0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, -0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, -0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, -0.5f, -0.5f)}, color});
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 1);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 3);
+                    }
+                    // Right face
+                    if (x == CHUNK_WIDTH - 1 || m_blocks[x + 1][y][z] == BlockType::Air)
+                    {
+                        uint16_t baseIndex = m_vertices.size();
+                        m_vertices.push_back({{position + glm::vec3(0.5f, -0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, -0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, 0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(0.5f, 0.5f, 0.5f)}, color});
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 1);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 3);
+                        m_indices.push_back(baseIndex);
+                    }
+                    // Left face
+                    if (x == 0 || m_blocks[x - 1][y][z] == BlockType::Air)
+                    {
+                        uint16_t baseIndex = m_vertices.size();
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, -0.5f, 0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, -0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, 0.5f, -0.5f)}, color});
+                        m_vertices.push_back({{position + glm::vec3(-0.5f, 0.5f, 0.5f)}, color});
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 1);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex);
+                        m_indices.push_back(baseIndex + 3);
+                    }
+                }
+            }
+        }
+    }
+
+} // namespace flint

--- a/src/flint/chunk.hpp
+++ b/src/flint/chunk.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+#include <glm/glm.hpp>
+#include <vector>
+
+#include "graphics/mesh.hpp"
+
+namespace flint
+{
+    const int CHUNK_WIDTH = 16;
+    const int CHUNK_HEIGHT = 32;
+    const int CHUNK_DEPTH = 16;
+
+    enum class BlockType
+    {
+        Air,
+        Dirt,
+        Grass,
+    };
+
+    class Chunk
+    {
+    public:
+        Chunk();
+        ~Chunk();
+
+        bool initialize(WGPUDevice device);
+        void cleanup();
+
+        void render(WGPURenderPassEncoder renderPass) const;
+
+    private:
+        void generateChunkData();
+        void generateMesh();
+
+        BlockType m_blocks[CHUNK_WIDTH][CHUNK_HEIGHT][CHUNK_DEPTH];
+
+        // CPU data
+        std::vector<graphics::Vertex> m_vertices;
+        std::vector<uint16_t> m_indices;
+
+        // GPU buffers
+        WGPUBuffer m_vertexBuffer = nullptr;
+        WGPUBuffer m_indexBuffer = nullptr;
+        WGPUDevice m_device = nullptr;
+    };
+
+} // namespace flint


### PR DESCRIPTION
This commit introduces the rendering of a single 16x32x16 chunk of blocks, displaying dirt with a layer of grass on top.

Key changes:
- Added a `Chunk` class to manage block data and generate the chunk mesh.
- The `Chunk` class creates a 16x32x16 chunk with a layer of grass on top of dirt.
- Integrated the `Chunk` class into the main application, replacing the single cube rendering.
- Adjusted the camera position to provide a suitable view of the chunk.
- Block colors are used for rendering: green for grass and brown for dirt.