### PR TITLE
feat: Add macOS universal build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,42 @@ jobs:
       with:
         name: flint-and-timber-Windows
         path: artifact/
+
+  build-macos-universal:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Cache Build
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/release-arm64
+          build/release-x86_64
+        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'webgpu/dawn/dawn-git-tag.txt', 'sdl3-git-tag.txt') }}
+
+    - name: Build for Apple Silicon (ARM64)
+      run: |
+        cmake -S . -B build/release-arm64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64
+        cmake --build build/release-arm64 --config Release
+
+    - name: Build for Intel (x86_64)
+      run: |
+        cmake -S . -B build/release-x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
+        cmake --build build/release-x86_64 --config Release
+
+    - name: Create Universal Binary
+      run: |
+        mkdir -p artifact
+        lipo -create -output artifact/flint-and-timber \
+          build/release-arm64/flint-and-timber \
+          build/release-x86_64/flint-and-timber
+        cp build/release-arm64/libwebgpu_dawn.dylib artifact/
+        cp build/release-arm64/_deps/sdl3-build/libSDL3.dylib artifact/
+
+    - name: Upload Executable Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: flint-and-timber-macOS-Universal
+        path: artifact/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,14 +97,21 @@ jobs:
         cmake -S . -B build/release-x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
         cmake --build build/release-x86_64 --config Release
 
-    - name: Create Universal Binary
+    - name: Create Universal Binaries
       run: |
         mkdir -p artifact
+        # Create universal executable
         lipo -create -output artifact/flint-and-timber \
           build/release-arm64/flint-and-timber \
           build/release-x86_64/flint-and-timber
-        cp build/release-arm64/libwebgpu_dawn.dylib artifact/
-        cp build/release-arm64/_deps/sdl3-build/libSDL3.dylib artifact/
+        # Create universal dawn library
+        lipo -create -output artifact/libwebgpu_dawn.dylib \
+          build/release-arm64/libwebgpu_dawn.dylib \
+          build/release-x86_64/libwebgpu_dawn.dylib
+        # Create universal SDL3 library
+        lipo -create -output artifact/libSDL3.dylib \
+          build/release-arm64/_deps/sdl3-build/libSDL3.dylib \
+          build/release-x86_64/_deps/sdl3-build/libSDL3.dylib
 
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,9 +109,9 @@ jobs:
           build/release-arm64/libwebgpu_dawn.dylib \
           build/release-x86_64/libwebgpu_dawn.dylib
         # Create universal SDL3 library
-        lipo -create -output artifact/libSDL3.dylib \
-          build/release-arm64/_deps/sdl3-build/libSDL3.dylib \
-          build/release-x86_64/_deps/sdl3-build/libSDL3.dylib
+        lipo -create -output artifact/libSDL3.0.dylib \
+          build/release-arm64/_deps/sdl3-build/libSDL3.0.dylib \
+          build/release-x86_64/_deps/sdl3-build/libSDL3.0.dylib
 
     - name: Upload Executable Artifact
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,16 @@ if(UNIX AND NOT APPLE)
     )
 endif()
 
+# Set RPATH for macOS to find shared libraries in the executable's directory
+if(APPLE)
+    set_target_properties(${TARGET_NAME} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+    set_target_properties(${TARGET_NAME} PROPERTIES
+        INSTALL_RPATH "@executable_path"
+    )
+endif()
+
 # Include directories
 target_include_directories(${TARGET_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/webgpu/include


### PR DESCRIPTION
Extends the GitHub Actions workflow to build a universal binary for macOS.

The new `build-macos-universal` job builds for both `aarch64-apple-darwin` (Apple Silicon) and `x86_64-apple-darwin` (Intel). It then uses the `lipo` tool to combine the two executables into a single universal binary.

The necessary dynamic libraries for Dawn and SDL3 are also included in the final artifact, allowing the application to run on both Apple Silicon and Intel-based Macs.