### PR TITLE
ci: Bundle SDL3 library for Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         path: |
           build/release/flint-and-timber
           build/release/libwebgpu_dawn.so
+          build/release/_deps/sdl3-build/libSDL3.so
 
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
The GitHub Actions workflow for Windows was already bundling the SDL3.dll with the build artifacts. This change updates the Linux workflow to do the same by including libSDL3.so in the uploaded artifact.

This is necessary because the executable's RPATH is set to '$ORIGIN', meaning it expects to find its shared libraries in the same directory. Without bundling the library, the executable would fail to run on systems without a system-wide installation of SDL3.