### PR TITLE
Fix: Correct cache key paths in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build/release
-        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'webgpu/dawn/dawn-git-tag.txt', 'sdl3-git-tag.txt') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'third_party/webgpu/dawn/dawn-git-tag.txt', 'third_party/sdl3-git-tag.txt') }}
 
     - name: Install dependencies
       run: >
@@ -49,7 +49,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build/release
-        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'webgpu/dawn/dawn-git-tag.txt', 'sdl3-git-tag.txt') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'third_party/webgpu/dawn/dawn-git-tag.txt', 'third_party/sdl3-git-tag.txt') }}
 
     - name: Set up MSBuild
       uses: microsoft/setup-msbuild@v1.3
@@ -86,7 +86,7 @@ jobs:
         path: |
           build/release-arm64
           build/release-x86_64
-        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'webgpu/dawn/dawn-git-tag.txt', 'sdl3-git-tag.txt') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('CMakeLists.txt', 'third_party/webgpu/dawn/dawn-git-tag.txt', 'third_party/sdl3-git-tag.txt') }}
 
     - name: Build for Apple Silicon (ARM64)
       run: |


### PR DESCRIPTION
The cache key in the GitHub Actions workflow was using incorrect paths for `dawn-git-tag.txt` and `sdl3-git-tag.txt`. This resulted in the cache not being properly utilized.

This change updates the paths to `third_party/webgpu/dawn/dawn-git-tag.txt` and `third_party/sdl3-git-tag.txt` for all build systems (Linux, Windows, and macOS) to ensure the cache key is generated correctly.