### PR TITLE
fix(graphics): Correct vertex winding order for chunk meshing

### DIFF
--- a/src/flint/chunk.cpp
+++ b/src/flint/chunk.cpp
@@ -228,12 +228,13 @@ namespace flint
                             m_vertices.push_back({position + face_vertices[i], uvs[i]});
                         }
 
-                        m_indices.push_back(baseIndex);
-                        m_indices.push_back(baseIndex + 2);
+                        // Corrected winding order for CCW faces
+                        m_indices.push_back(baseIndex + 0);
                         m_indices.push_back(baseIndex + 1);
-                        m_indices.push_back(baseIndex);
-                        m_indices.push_back(baseIndex + 3);
                         m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 0);
+                        m_indices.push_back(baseIndex + 2);
+                        m_indices.push_back(baseIndex + 3);
                     };
 
                     // Front face (+z)


### PR DESCRIPTION
The previous implementation defined the indices for chunk face quads in a clockwise (CW) order. Most rendering pipelines, including the one used in this project, default to counter-clockwise (CCW) winding for determining the front face of a polygon.

This mismatch caused back-face culling to incorrectly discard the polygons that should have been visible from the outside, making chunks and other objects appear hollow or inverted.

This commit corrects the index order in `src/flint/chunk.cpp` to follow a CCW winding. This aligns the C++ implementation with the reference Rust implementation and standard graphics conventions, resolving the rendering bug.