### PR TITLE
Refactor App constructor into logical init functions

### DIFF
--- a/src/flint/app.cpp
+++ b/src/flint/app.cpp
@@ -2,19 +2,12 @@
 #include <iostream>
 #include "init/sdl.h"
 #include "init/wgpu.h"
+#include "init/utils.h"
+#include "init/mesh.h"
+#include "init/shader.h"
+#include "init/buffer.h"
+#include "init/pipeline.h"
 #include "shader.wgsl.h"
-
-namespace
-{
-
-    WGPUStringView makeStringView(const char *str)
-    {
-        return WGPUStringView{
-            .data = str,
-            .length = str ? strlen(str) : 0};
-    }
-
-}
 
 namespace flint
 {
@@ -37,67 +30,12 @@ namespace flint
             m_queue //
         );
 
-        std::cout << "Creating triangle vertex data..." << std::endl;
-
-        // Triangle vertices in NDC coordinates (x, y, z)
-        float triangleVertices[] = {
-            0.0f, 0.5f, 0.0f,   // Top vertex
-            -0.5f, -0.5f, 0.0f, // Bottom left
-            0.5f, -0.5f, 0.0f   // Bottom right
-        };
-
-        // Create vertex buffer descriptor
-        WGPUBufferDescriptor vertexBufferDesc = {};
-        vertexBufferDesc.nextInChain = nullptr;
-        vertexBufferDesc.label = makeStringView("Triangle Vertex Buffer");
-        vertexBufferDesc.size = sizeof(triangleVertices);
-        vertexBufferDesc.usage = WGPUBufferUsage_Vertex | WGPUBufferUsage_CopyDst;
-        vertexBufferDesc.mappedAtCreation = false;
-
-        // Create the vertex buffer
-        m_vertexBuffer = wgpuDeviceCreateBuffer(m_device, &vertexBufferDesc);
-        if (!m_vertexBuffer)
-        {
-            std::cerr << "Failed to create vertex buffer!" << std::endl;
-            throw std::runtime_error("Failed to create vertex buffer!");
-        }
-
-        // Upload vertex data to GPU
-        wgpuQueueWriteBuffer(m_queue, m_vertexBuffer, 0, triangleVertices, sizeof(triangleVertices));
-
-        std::cout << "Vertex buffer created and data uploaded" << std::endl;
+        m_vertexBuffer = init::create_triangle_vertex_buffer(m_device, m_queue);
 
         std::cout << "Creating shaders..." << std::endl;
 
-        // Create vertex shader module
-        WGPUShaderModuleWGSLDescriptor vertexShaderWGSLDesc = {};
-        vertexShaderWGSLDesc.chain.next = nullptr;
-        vertexShaderWGSLDesc.chain.sType = WGPUSType_ShaderSourceWGSL;
-        vertexShaderWGSLDesc.code = makeStringView(WGSL_vertexShaderSource);
-
-        WGPUShaderModuleDescriptor vertexShaderDesc = {};
-        vertexShaderDesc.nextInChain = &vertexShaderWGSLDesc.chain;
-        vertexShaderDesc.label = makeStringView("Vertex Shader");
-
-        m_vertexShader = wgpuDeviceCreateShaderModule(m_device, &vertexShaderDesc);
-
-        // Create fragment shader module
-        WGPUShaderModuleWGSLDescriptor fragmentShaderWGSLDesc = {};
-        fragmentShaderWGSLDesc.chain.next = nullptr;
-        fragmentShaderWGSLDesc.chain.sType = WGPUSType_ShaderSourceWGSL;
-        fragmentShaderWGSLDesc.code = makeStringView(WGSL_fragmentShaderSource);
-
-        WGPUShaderModuleDescriptor fragmentShaderDesc = {};
-        fragmentShaderDesc.nextInChain = &fragmentShaderWGSLDesc.chain;
-        fragmentShaderDesc.label = makeStringView("Fragment Shader");
-
-        m_fragmentShader = wgpuDeviceCreateShaderModule(m_device, &fragmentShaderDesc);
-
-        if (!m_vertexShader || !m_fragmentShader)
-        {
-            std::cerr << "Failed to create shaders!" << std::endl;
-            throw std::runtime_error("Failed to create shaders!");
-        }
+        m_vertexShader = init::create_shader_module(m_device, "Vertex Shader", WGSL_vertexShaderSource);
+        m_fragmentShader = init::create_shader_module(m_device, "Fragment Shader", WGSL_fragmentShaderSource);
 
         std::cout << "Shaders created successfully" << std::endl;
 
@@ -116,131 +54,18 @@ namespace flint
         }
 
         // Create uniform buffer for camera matrices
-        WGPUBufferDescriptor uniformBufferDesc = {};
-        uniformBufferDesc.size = sizeof(glm::mat4); // Size of view-projection matrix
-        uniformBufferDesc.usage = WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst;
-        uniformBufferDesc.mappedAtCreation = false;
-
-        m_uniformBuffer = wgpuDeviceCreateBuffer(m_device, &uniformBufferDesc);
-        if (!m_uniformBuffer)
-        {
-            std::cerr << "Failed to create uniform buffer!" << std::endl;
-            throw std::runtime_error("Failed to create uniform buffer!");
-        }
+        m_uniformBuffer = init::create_uniform_buffer(m_device, "Camera Uniform Buffer", sizeof(glm::mat4));
 
         std::cout << "3D components ready!" << std::endl;
 
-        std::cout << "Creating render pipeline..." << std::endl;
+        m_renderPipeline = init::create_render_pipeline(
+            m_device,
+            m_vertexShader,
+            m_fragmentShader,
+            m_surfaceFormat,
+            &m_bindGroupLayout);
 
-        // Create bind group layout for uniforms first
-        WGPUBindGroupLayoutEntry bindingLayout = {};
-        bindingLayout.binding = 0;
-        bindingLayout.visibility = WGPUShaderStage_Vertex;
-        bindingLayout.buffer.type = WGPUBufferBindingType_Uniform;
-        bindingLayout.buffer.minBindingSize = sizeof(glm::mat4);
-
-        WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc = {};
-        bindGroupLayoutDesc.entryCount = 1;
-        bindGroupLayoutDesc.entries = &bindingLayout;
-
-        m_bindGroupLayout = wgpuDeviceCreateBindGroupLayout(m_device, &bindGroupLayoutDesc);
-        if (!m_bindGroupLayout)
-        {
-            std::cerr << "Failed to create bind group layout!" << std::endl;
-            throw std::runtime_error("Failed to create bind group layout!");
-        }
-
-        // Create pipeline layout using our bind group layout
-        WGPUPipelineLayoutDescriptor pipelineLayoutDesc = {};
-        pipelineLayoutDesc.bindGroupLayoutCount = 1;
-        pipelineLayoutDesc.bindGroupLayouts = &m_bindGroupLayout;
-
-        WGPUPipelineLayout pipelineLayout = wgpuDeviceCreatePipelineLayout(m_device, &pipelineLayoutDesc);
-
-        // NEW: Define vertex buffer layout for position + color
-        WGPUVertexAttribute vertexAttributes[2] = {};
-
-        // Position attribute (location 0)
-        vertexAttributes[0].format = WGPUVertexFormat_Float32x3; // vec3f position
-        vertexAttributes[0].offset = 0;
-        vertexAttributes[0].shaderLocation = 0;
-
-        // Color attribute (location 1)
-        vertexAttributes[1].format = WGPUVertexFormat_Float32x3; // vec3f color
-        vertexAttributes[1].offset = 3 * sizeof(float);          // After position
-        vertexAttributes[1].shaderLocation = 1;
-
-        WGPUVertexBufferLayout vertexBufferLayout = {};
-        vertexBufferLayout.arrayStride = 6 * sizeof(float); // 3 floats position + 3 floats color
-        vertexBufferLayout.stepMode = WGPUVertexStepMode_Vertex;
-        vertexBufferLayout.attributeCount = 2; // position + color
-        vertexBufferLayout.attributes = vertexAttributes;
-
-        // Create render pipeline descriptor
-        WGPURenderPipelineDescriptor pipelineDescriptor = {};
-        pipelineDescriptor.label = makeStringView("Cube Render Pipeline");
-
-        // Vertex state
-        pipelineDescriptor.vertex.module = m_vertexShader;
-        pipelineDescriptor.vertex.entryPoint = makeStringView("vs_main");
-        pipelineDescriptor.vertex.bufferCount = 1;
-        pipelineDescriptor.vertex.buffers = &vertexBufferLayout;
-
-        // Fragment state
-        WGPUFragmentState fragmentState = {};
-        fragmentState.module = m_fragmentShader;
-        fragmentState.entryPoint = makeStringView("fs_main");
-
-        // Color target (what we're rendering to)
-        WGPUColorTargetState colorTarget = {};
-        colorTarget.format = m_surfaceFormat;
-        colorTarget.writeMask = WGPUColorWriteMask_All;
-
-        fragmentState.targetCount = 1;
-        fragmentState.targets = &colorTarget;
-        pipelineDescriptor.fragment = &fragmentState;
-
-        // Primitive state - IMPORTANT: Enable depth testing for 3D
-        pipelineDescriptor.primitive.topology = WGPUPrimitiveTopology_TriangleList;
-        pipelineDescriptor.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
-        pipelineDescriptor.primitive.frontFace = WGPUFrontFace_CCW;
-        pipelineDescriptor.primitive.cullMode = WGPUCullMode_Back; // Enable back-face culling
-
-        // Multisample state
-        pipelineDescriptor.multisample.count = 1;
-        pipelineDescriptor.multisample.mask = 0xFFFFFFFF;
-        pipelineDescriptor.multisample.alphaToCoverageEnabled = false;
-
-        // Use our custom layout (not auto)
-        pipelineDescriptor.layout = pipelineLayout;
-
-        // Create the pipeline
-        m_renderPipeline = wgpuDeviceCreateRenderPipeline(m_device, &pipelineDescriptor);
-
-        // Clean up temporary layout
-        wgpuPipelineLayoutRelease(pipelineLayout);
-
-        if (!m_renderPipeline)
-        {
-            std::cerr << "Failed to create render pipeline!" << std::endl;
-            throw std::runtime_error("Failed to create render pipeline!");
-        }
-
-        // Create bind group for uniforms
-        WGPUBindGroupEntry binding = {};
-        binding.binding = 0;
-        binding.buffer = m_uniformBuffer;
-        binding.offset = 0;
-        binding.size = sizeof(glm::mat4);
-
-        WGPUBindGroupDescriptor bindGroupDesc = {};
-        bindGroupDesc.layout = m_bindGroupLayout;
-        bindGroupDesc.entryCount = 1;
-        bindGroupDesc.entries = &binding;
-
-        m_bindGroup = wgpuDeviceCreateBindGroup(m_device, &bindGroupDesc);
-
-        std::cout << "Render pipeline created successfully" << std::endl;
+        m_bindGroup = init::create_bind_group(m_device, m_bindGroupLayout, m_uniformBuffer);
 
         // ====
         m_running = true;

--- a/src/flint/init/buffer.cpp
+++ b/src/flint/init/buffer.cpp
@@ -1,0 +1,29 @@
+#include "buffer.h"
+
+#include <iostream>
+#include <stdexcept>
+
+#include "utils.h"
+
+namespace flint::init
+{
+
+    WGPUBuffer create_uniform_buffer(WGPUDevice device, const char *label, uint64_t size)
+    {
+        WGPUBufferDescriptor uniformBufferDesc = {};
+        uniformBufferDesc.label = makeStringView(label);
+        uniformBufferDesc.size = size;
+        uniformBufferDesc.usage = WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst;
+        uniformBufferDesc.mappedAtCreation = false;
+
+        WGPUBuffer uniformBuffer = wgpuDeviceCreateBuffer(device, &uniformBufferDesc);
+        if (!uniformBuffer)
+        {
+            std::cerr << "Failed to create uniform buffer: " << label << std::endl;
+            throw std::runtime_error("Failed to create uniform buffer!");
+        }
+
+        return uniformBuffer;
+    }
+
+} // namespace flint::init

--- a/src/flint/init/buffer.h
+++ b/src/flint/init/buffer.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+namespace flint::init
+{
+
+    WGPUBuffer create_uniform_buffer(WGPUDevice device, const char *label, uint64_t size);
+
+} // namespace flint::init

--- a/src/flint/init/mesh.cpp
+++ b/src/flint/init/mesh.cpp
@@ -1,0 +1,46 @@
+#include "mesh.h"
+
+#include <iostream>
+#include <stdexcept>
+
+#include "utils.h"
+
+namespace flint::init
+{
+
+    WGPUBuffer create_triangle_vertex_buffer(WGPUDevice device, WGPUQueue queue)
+    {
+        std::cout << "Creating triangle vertex data..." << std::endl;
+
+        // Triangle vertices in NDC coordinates (x, y, z)
+        float triangleVertices[] = {
+            0.0f, 0.5f, 0.0f,   // Top vertex
+            -0.5f, -0.5f, 0.0f, // Bottom left
+            0.5f, -0.5f, 0.0f   // Bottom right
+        };
+
+        // Create vertex buffer descriptor
+        WGPUBufferDescriptor vertexBufferDesc = {};
+        vertexBufferDesc.nextInChain = nullptr;
+        vertexBufferDesc.label = makeStringView("Triangle Vertex Buffer");
+        vertexBufferDesc.size = sizeof(triangleVertices);
+        vertexBufferDesc.usage = WGPUBufferUsage_Vertex | WGPUBufferUsage_CopyDst;
+        vertexBufferDesc.mappedAtCreation = false;
+
+        // Create the vertex buffer
+        WGPUBuffer vertexBuffer = wgpuDeviceCreateBuffer(device, &vertexBufferDesc);
+        if (!vertexBuffer)
+        {
+            std::cerr << "Failed to create vertex buffer!" << std::endl;
+            throw std::runtime_error("Failed to create vertex buffer!");
+        }
+
+        // Upload vertex data to GPU
+        wgpuQueueWriteBuffer(queue, vertexBuffer, 0, triangleVertices, sizeof(triangleVertices));
+
+        std::cout << "Vertex buffer created and data uploaded" << std::endl;
+
+        return vertexBuffer;
+    }
+
+} // namespace flint::init

--- a/src/flint/init/mesh.h
+++ b/src/flint/init/mesh.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+namespace flint::init
+{
+
+    WGPUBuffer create_triangle_vertex_buffer(WGPUDevice device, WGPUQueue queue);
+
+} // namespace flint::init

--- a/src/flint/init/pipeline.cpp
+++ b/src/flint/init/pipeline.cpp
@@ -1,0 +1,145 @@
+#include "pipeline.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+#include "utils.h"
+
+namespace flint::init
+{
+
+    WGPURenderPipeline create_render_pipeline(
+        WGPUDevice device,
+        WGPUShaderModule vertexShader,
+        WGPUShaderModule fragmentShader,
+        WGPUTextureFormat surfaceFormat,
+        WGPUBindGroupLayout *pBindGroupLayout)
+    {
+        std::cout << "Creating render pipeline..." << std::endl;
+
+        // Create bind group layout for uniforms first
+        WGPUBindGroupLayoutEntry bindingLayout = {};
+        bindingLayout.binding = 0;
+        bindingLayout.visibility = WGPUShaderStage_Vertex;
+        bindingLayout.buffer.type = WGPUBufferBindingType_Uniform;
+        bindingLayout.buffer.minBindingSize = sizeof(glm::mat4);
+
+        WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc = {};
+        bindGroupLayoutDesc.entryCount = 1;
+        bindGroupLayoutDesc.entries = &bindingLayout;
+
+        WGPUBindGroupLayout bindGroupLayout = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
+        if (!bindGroupLayout)
+        {
+            std::cerr << "Failed to create bind group layout!" << std::endl;
+            throw std::runtime_error("Failed to create bind group layout!");
+        }
+        *pBindGroupLayout = bindGroupLayout; // Output the layout
+
+        // Create pipeline layout using our bind group layout
+        WGPUPipelineLayoutDescriptor pipelineLayoutDesc = {};
+        pipelineLayoutDesc.bindGroupLayoutCount = 1;
+        pipelineLayoutDesc.bindGroupLayouts = &bindGroupLayout;
+
+        WGPUPipelineLayout pipelineLayout = wgpuDeviceCreatePipelineLayout(device, &pipelineLayoutDesc);
+
+        // Define vertex buffer layout for position + color
+        std::vector<WGPUVertexAttribute> vertexAttributes(2);
+
+        // Position attribute (location 0)
+        vertexAttributes[0].format = WGPUVertexFormat_Float32x3; // vec3f position
+        vertexAttributes[0].offset = 0;
+        vertexAttributes[0].shaderLocation = 0;
+
+        // Color attribute (location 1)
+        vertexAttributes[1].format = WGPUVertexFormat_Float32x3; // vec3f color
+        vertexAttributes[1].offset = 3 * sizeof(float);          // After position
+        vertexAttributes[1].shaderLocation = 1;
+
+        WGPUVertexBufferLayout vertexBufferLayout = {};
+        vertexBufferLayout.arrayStride = 6 * sizeof(float); // 3 floats position + 3 floats color
+        vertexBufferLayout.stepMode = WGPUVertexStepMode_Vertex;
+        vertexBufferLayout.attributeCount = vertexAttributes.size();
+        vertexBufferLayout.attributes = vertexAttributes.data();
+
+        // Create render pipeline descriptor
+        WGPURenderPipelineDescriptor pipelineDescriptor = {};
+        pipelineDescriptor.label = makeStringView("Cube Render Pipeline");
+
+        // Vertex state
+        pipelineDescriptor.vertex.module = vertexShader;
+        pipelineDescriptor.vertex.entryPoint = makeStringView("vs_main");
+        pipelineDescriptor.vertex.bufferCount = 1;
+        pipelineDescriptor.vertex.buffers = &vertexBufferLayout;
+
+        // Fragment state
+        WGPUFragmentState fragmentState = {};
+        fragmentState.module = fragmentShader;
+        fragmentState.entryPoint = makeStringView("fs_main");
+
+        // Color target (what we're rendering to)
+        WGPUColorTargetState colorTarget = {};
+        colorTarget.format = surfaceFormat;
+        colorTarget.writeMask = WGPUColorWriteMask_All;
+
+        fragmentState.targetCount = 1;
+        fragmentState.targets = &colorTarget;
+        pipelineDescriptor.fragment = &fragmentState;
+
+        // Primitive state
+        pipelineDescriptor.primitive.topology = WGPUPrimitiveTopology_TriangleList;
+        pipelineDescriptor.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
+        pipelineDescriptor.primitive.frontFace = WGPUFrontFace_CCW;
+        pipelineDescriptor.primitive.cullMode = WGPUCullMode_Back;
+
+        // Multisample state
+        pipelineDescriptor.multisample.count = 1;
+        pipelineDescriptor.multisample.mask = 0xFFFFFFFF;
+        pipelineDescriptor.multisample.alphaToCoverageEnabled = false;
+
+        pipelineDescriptor.layout = pipelineLayout;
+
+        WGPURenderPipeline renderPipeline = wgpuDeviceCreateRenderPipeline(device, &pipelineDescriptor);
+
+        wgpuPipelineLayoutRelease(pipelineLayout);
+
+        if (!renderPipeline)
+        {
+            std::cerr << "Failed to create render pipeline!" << std::endl;
+            throw std::runtime_error("Failed to create render pipeline!");
+        }
+
+        std::cout << "Render pipeline created successfully" << std::endl;
+        return renderPipeline;
+    }
+
+    WGPUBindGroup create_bind_group(
+        WGPUDevice device,
+        WGPUBindGroupLayout bindGroupLayout,
+        WGPUBuffer uniformBuffer)
+    {
+        WGPUBindGroupEntry binding = {};
+        binding.binding = 0;
+        binding.buffer = uniformBuffer;
+        binding.offset = 0;
+        binding.size = sizeof(glm::mat4);
+
+        WGPUBindGroupDescriptor bindGroupDesc = {};
+        bindGroupDesc.layout = bindGroupLayout;
+        bindGroupDesc.entryCount = 1;
+        bindGroupDesc.entries = &binding;
+
+        WGPUBindGroup bindGroup = wgpuDeviceCreateBindGroup(device, &bindGroupDesc);
+        if (!bindGroup)
+        {
+            std::cerr << "Failed to create bind group!" << std::endl;
+            throw std::runtime_error("Failed to create bind group!");
+        }
+
+        return bindGroup;
+    }
+
+} // namespace flint::init

--- a/src/flint/init/pipeline.h
+++ b/src/flint/init/pipeline.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+namespace flint::init
+{
+
+    WGPURenderPipeline create_render_pipeline(
+        WGPUDevice device,
+        WGPUShaderModule vertexShader,
+        WGPUShaderModule fragmentShader,
+        WGPUTextureFormat surfaceFormat,
+        WGPUBindGroupLayout *pBindGroupLayout // Output parameter
+    );
+
+    WGPUBindGroup create_bind_group(
+        WGPUDevice device,
+        WGPUBindGroupLayout bindGroupLayout,
+        WGPUBuffer uniformBuffer);
+
+} // namespace flint::init

--- a/src/flint/init/shader.cpp
+++ b/src/flint/init/shader.cpp
@@ -1,0 +1,32 @@
+#include "shader.h"
+
+#include <iostream>
+#include <stdexcept>
+
+#include "utils.h"
+
+namespace flint::init
+{
+
+    WGPUShaderModule create_shader_module(WGPUDevice device, const char *label, const char *wgsl_source)
+    {
+        WGPUShaderModuleWGSLDescriptor shaderWGSLDesc = {};
+        shaderWGSLDesc.chain.next = nullptr;
+        shaderWGSLDesc.chain.sType = WGPUSType_ShaderSourceWGSL;
+        shaderWGSLDesc.code = makeStringView(wgsl_source);
+
+        WGPUShaderModuleDescriptor shaderDesc = {};
+        shaderDesc.nextInChain = &shaderWGSLDesc.chain;
+        shaderDesc.label = makeStringView(label);
+
+        WGPUShaderModule shaderModule = wgpuDeviceCreateShaderModule(device, &shaderDesc);
+        if (!shaderModule)
+        {
+            std::cerr << "Failed to create shader module: " << label << std::endl;
+            throw std::runtime_error("Failed to create shader module");
+        }
+
+        return shaderModule;
+    }
+
+} // namespace flint::init

--- a/src/flint/init/shader.h
+++ b/src/flint/init/shader.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+namespace flint::init
+{
+
+    WGPUShaderModule create_shader_module(WGPUDevice device, const char *label, const char *wgsl_source);
+
+} // namespace flint::init

--- a/src/flint/init/utils.h
+++ b/src/flint/init/utils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+#include <cstring>
+
+namespace flint::init
+{
+
+    inline WGPUStringView makeStringView(const char *str)
+    {
+        return WGPUStringView{
+            .data = str,
+            .length = str ? strlen(str) : 0};
+    }
+
+} // namespace flint::init


### PR DESCRIPTION
Refactor the `App::App` constructor into smaller, more manageable initialization functions.

This change breaks down the monolithic `App::App` constructor into several logical blocks, each responsible for a specific part of the initialization process (e.g., creating vertex buffers, shaders, uniform buffers, and the render pipeline).

The new functions are organized into the `flint::init` namespace and placed in separate files within the `src/flint/init/` directory, following the existing pattern of `init::sdl` and `init::wgpu`.

This refactoring improves code modularity, readability, and maintainability without changing the application's overall behavior.