### PR TITLE
fix(player): Correct inverted strafing logic to fix collision bug

### DIFF
--- a/src/flint/player.cpp
+++ b/src/flint/player.cpp
@@ -93,16 +93,17 @@ namespace flint
             glm::vec3 intended_horizontal_velocity(0.0f);
             float yaw_radians = glm::radians(yaw);
             glm::vec3 horizontal_forward = glm::normalize(glm::vec3(cos(yaw_radians), 0.0f, sin(yaw_radians)));
-            glm::vec3 horizontal_right = glm::normalize(glm::cross(horizontal_forward, glm::vec3(0, 1, 0)));
+            // In a right-handed Y-up system, forward x up = left. The variable is misnamed.
+            glm::vec3 horizontal_left = glm::normalize(glm::cross(horizontal_forward, glm::vec3(0, 1, 0)));
 
             if (movement_intention.forward)
                 intended_horizontal_velocity += horizontal_forward;
             if (movement_intention.backward)
                 intended_horizontal_velocity -= horizontal_forward;
             if (movement_intention.left)
-                intended_horizontal_velocity -= horizontal_right;
+                intended_horizontal_velocity += horizontal_left;
             if (movement_intention.right)
-                intended_horizontal_velocity += horizontal_right;
+                intended_horizontal_velocity -= horizontal_left;
 
             if (glm::length2(intended_horizontal_velocity) > 0.0f)
             {


### PR DESCRIPTION
The player's strafing controls were inverted due to a misunderstanding of the cross product result in a right-handed coordinate system. The `horizontal_right` vector was actually pointing left.

This caused the player's input to fight against the collision response system when moving against a wall, leading to an asymmetrical collision bug where the player would clip into the block from two directions.

This commit fixes the issue by:
1. Renaming the misnamed vector to `horizontal_left` for clarity.
2. Swapping the `+=` and `-=` operators in the movement logic to correctly handle left and right strafing based on the calculated vector.