### PR TITLE
This commit introduces a hardcoded oak tree into the world generation.

### DIFF
--- a/src/flint/block.cpp
+++ b/src/flint/block.cpp
@@ -11,8 +11,10 @@ namespace flint
         {
         case BlockType::Grass:
         case BlockType::Dirt:
+        case BlockType::OakLog:
             return true;
         case BlockType::Air:
+        case BlockType::OakLeaves:
         default:
             return false;
         }

--- a/src/flint/block.h
+++ b/src/flint/block.h
@@ -8,7 +8,9 @@ namespace flint
     {
         Air,
         Dirt,
-        Grass
+    Grass,
+    OakLog,
+    OakLeaves
     };
 
     // This is the C++ equivalent of your Rust `pub struct Block`.

--- a/src/flint/chunk.cpp
+++ b/src/flint/chunk.cpp
@@ -44,6 +44,37 @@ namespace flint
         setBlock(7, pillar_y_start + 1, 5, BlockType::Dirt);
         setBlock(7, pillar_y_start, 7, BlockType::Dirt);
         setBlock(7, pillar_y_start + 1, 7, BlockType::Dirt);
+
+        // Add a hardcoded tree
+        const size_t tree_x = 8;
+        const size_t tree_z = 8;
+        const size_t trunk_height = 5;
+        const size_t trunk_y_start = surface_level + 1;
+
+        // Trunk
+        for (size_t i = 0; i < trunk_height; ++i)
+        {
+            setBlock(tree_x, trunk_y_start + i, tree_z, BlockType::OakLog);
+        }
+
+        // Canopy
+        const size_t canopy_y_start = trunk_y_start + trunk_height;
+        for (int dx = -2; dx <= 2; ++dx)
+        {
+            for (int dy = -1; dy <= 1; ++dy)
+            {
+                for (int dz = -2; dz <= 2; ++dz)
+                {
+                    if (dx * dx + dy * dy + dz * dz <= 5)
+                    {
+                        // Avoid replacing the top of the trunk
+                        if (dx == 0 && dz == 0 && dy <= 0) continue;
+
+                        setBlock(tree_x + dx, canopy_y_start + dy, tree_z + dz, BlockType::OakLeaves);
+                    }
+                }
+            }
+        }
     }
 
     const Block *Chunk::getBlock(size_t x, size_t y, size_t z) const

--- a/src/flint/chunk.cpp
+++ b/src/flint/chunk.cpp
@@ -46,8 +46,8 @@ namespace flint
         setBlock(7, pillar_y_start + 1, 7, BlockType::Dirt);
 
         // Add a hardcoded tree
-        const size_t tree_x = 8;
-        const size_t tree_z = 8;
+        const size_t tree_x = 4;
+        const size_t tree_z = 4;
         const size_t trunk_height = 5;
         const size_t trunk_y_start = surface_level + 1;
 

--- a/src/flint/graphics/chunk_mesh.cpp
+++ b/src/flint/graphics/chunk_mesh.cpp
@@ -43,6 +43,21 @@ namespace
             }
             break;
         case flint::BlockType::Dirt:
+            tile_coords = {2, 0}; // Dirt
+            break;
+        case flint::BlockType::OakLog:
+            if (face == flint::CubeGeometry::Face::Top || face == flint::CubeGeometry::Face::Bottom)
+            {
+                tile_coords = {5, 0}; // Oak log top/bottom
+            }
+            else
+            {
+                tile_coords = {4, 0}; // Oak log side
+            }
+            break;
+        case flint::BlockType::OakLeaves:
+            tile_coords = {6, 0}; // Oak leaves
+            break;
         default:
             tile_coords = {2, 0}; // Dirt
             break;
@@ -131,7 +146,7 @@ namespace flint
                     for (size_t z = 0; z < CHUNK_DEPTH; ++z)
                     {
                         const Block *currentBlock = chunk.getBlock(x, y, z);
-                        if (!currentBlock || !currentBlock->isSolid())
+                        if (!currentBlock || currentBlock->type == BlockType::Air)
                         {
                             continue;
                         }

--- a/src/flint/graphics/chunk_mesh.cpp
+++ b/src/flint/graphics/chunk_mesh.cpp
@@ -57,6 +57,9 @@ namespace
             break;
         case flint::BlockType::OakLeaves:
             tile_coords = {6, 0}; // Oak leaves
+            // Use the sentinel color to signal the shader to apply a tint,
+            // the same way we do for grass.
+            color = {0.1f, 0.9f, 0.1f};
             break;
         default:
             tile_coords = {2, 0}; // Dirt

--- a/src/flint/shader.wgsl.h
+++ b/src/flint/shader.wgsl.h
@@ -50,6 +50,12 @@ const TINT_SENTINEL = vec3<f32>(0.1, 0.9, 0.1);
 fn fs_main(in: FragmentInput) -> @location(0) vec4<f32> {
     let texture_color = textureSample(t_atlas, s_atlas, in.uv);
 
+    // Alpha test for transparent textures (e.g., leaves).
+    // If the alpha value is below a threshold, discard the fragment.
+    if (texture_color.a < 0.1) {
+        discard;
+    }
+
     // If the vertex color is the sentinel value, tint the texture.
     // Otherwise, use the texture color directly.
     if (all(in.color == TINT_SENTINEL)) {


### PR DESCRIPTION
Key changes:
- Added `OakLog` and `OakLeaves` to the `BlockType` enum.
- Updated `Block::isSolid()` to correctly handle the new block types.
- Modified `chunk_mesh.cpp` to map the correct textures to the new blocks, including direction-specific textures for logs.
- Adjusted the mesh generation logic to ensure transparent blocks (leaves) are rendered correctly.
- Added a tree generation algorithm to `Chunk::generateTerrain` that places a single oak tree with a trunk and a spherical canopy.