### PR TITLE
feat: Relocate tree and color oak leaves

### DIFF
--- a/src/flint/chunk.cpp
+++ b/src/flint/chunk.cpp
@@ -46,8 +46,8 @@ namespace flint
         setBlock(7, pillar_y_start + 1, 7, BlockType::Dirt);
 
         // Add a hardcoded tree
-        const size_t tree_x = 8;
-        const size_t tree_z = 8;
+        const size_t tree_x = 4;
+        const size_t tree_z = 4;
         const size_t trunk_height = 5;
         const size_t trunk_y_start = surface_level + 1;
 

--- a/src/flint/graphics/chunk_mesh.cpp
+++ b/src/flint/graphics/chunk_mesh.cpp
@@ -57,6 +57,9 @@ namespace
             break;
         case flint::BlockType::OakLeaves:
             tile_coords = {6, 0}; // Oak leaves
+            // Use the sentinel color to signal the shader to apply a tint,
+            // the same way we do for grass.
+            color = {0.1f, 0.9f, 0.1f};
             break;
         default:
             tile_coords = {2, 0}; // Dirt


### PR DESCRIPTION
This commit introduces two changes to the world generation:

1.  The hardcoded tree has been moved from `(8, 8)` to `(4, 4)` to place it in the center of the top-left chunk quarter.
2.  Oak leaves are now colored using the same tinting mechanism as grass blocks. This is achieved by passing a sentinel color from the mesh generation to the shader, which then applies a green tint.