### PR TITLE
Build inventory UI with button interaction

### DIFF
--- a/src/flint/app.cpp
+++ b/src/flint/app.cpp
@@ -171,11 +171,8 @@ namespace flint
                 }
             }
 
-            // Update player physics and state (only when inventory is closed)
-            if (!m_showInventory)
-            {
-                m_player.update(dt, m_worldRenderer.getWorld());
-            }
+            // Update player physics and state (always update - world continues even with inventory open)
+            m_player.update(dt, m_worldRenderer.getWorld());
 
             // Render the scene
             render();

--- a/src/flint/app.cpp
+++ b/src/flint/app.cpp
@@ -99,8 +99,11 @@ namespace flint
                 // Let debug screen renderer process the event first
                 m_debugScreenRenderer.process_event(e);
 
-                // Let the player handle keyboard input
-                m_player.handle_input(e);
+                // Let the player handle keyboard input (only when inventory is closed)
+                if (!m_showInventory)
+                {
+                    m_player.handle_input(e);
+                }
 
                 if (e.type == SDL_EVENT_QUIT)
                 {
@@ -124,6 +127,18 @@ namespace flint
                 else if (e.type == SDL_EVENT_KEY_DOWN && e.key.key == SDLK_E)
                 {
                     m_showInventory = !m_showInventory;
+
+                    // Toggle mouse grab when inventory is toggled
+                    if (m_showInventory)
+                    {
+                        // Opening inventory - ungrab mouse
+                        SDL_SetWindowRelativeMouseMode(m_window, false);
+                    }
+                    else
+                    {
+                        // Closing inventory - grab mouse again
+                        SDL_SetWindowRelativeMouseMode(m_window, true);
+                    }
                 }
                 else if (e.type == SDL_EVENT_WINDOW_RESIZED) {
                     onResize(e.window.data1, e.window.data2);
@@ -137,6 +152,12 @@ namespace flint
                 }
                 else if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
                 {
+                    // Don't handle mouse clicks when inventory is open
+                    if (m_showInventory)
+                    {
+                        continue;
+                    }
+
                     if (!SDL_GetWindowRelativeMouseMode(m_window))
                     {
                         SDL_SetWindowRelativeMouseMode(m_window, true);
@@ -150,8 +171,11 @@ namespace flint
                 }
             }
 
-            // Update player physics and state
-            m_player.update(dt, m_worldRenderer.getWorld());
+            // Update player physics and state (only when inventory is closed)
+            if (!m_showInventory)
+            {
+                m_player.update(dt, m_worldRenderer.getWorld());
+            }
 
             // Render the scene
             render();

--- a/src/flint/app.h
+++ b/src/flint/app.h
@@ -10,6 +10,7 @@
 #include "graphics/selection_renderer.h"
 #include "graphics/crosshair_renderer.h"
 #include "graphics/debug_screen_renderer.h"
+#include "graphics/inventory_ui_renderer.h"
 #include "player.h"
 
 namespace flint
@@ -52,6 +53,7 @@ namespace flint
         graphics::SelectionRenderer m_selectionRenderer;
         graphics::CrosshairRenderer m_crosshairRenderer;
         graphics::DebugScreenRenderer m_debugScreenRenderer;
+        graphics::InventoryUIRenderer m_inventoryUIRenderer;
 
         Camera m_camera;
         player::Player m_player;
@@ -59,6 +61,7 @@ namespace flint
         // App state
         bool m_running = false;
         bool m_showDebugScreen = false;
+        bool m_showInventory = false;
         int m_windowWidth = 800;
         int m_windowHeight = 600;
         float m_initialFovY = 60.0f;

--- a/src/flint/app.h
+++ b/src/flint/app.h
@@ -9,8 +9,7 @@
 #include "graphics/world_renderer.h"
 #include "graphics/selection_renderer.h"
 #include "graphics/crosshair_renderer.h"
-#include "graphics/debug_screen_renderer.h"
-#include "graphics/inventory_ui_renderer.h"
+#include "ui/ui_manager.h"
 #include "player.h"
 #include "game_state.h"
 
@@ -55,8 +54,7 @@ namespace flint
         graphics::WorldRenderer m_worldRenderer;
         graphics::SelectionRenderer m_selectionRenderer;
         graphics::CrosshairRenderer m_crosshairRenderer;
-        graphics::DebugScreenRenderer m_debugScreenRenderer;
-        graphics::InventoryUIRenderer m_inventoryUIRenderer;
+        ui::UIManager m_uiManager;
 
         Camera m_camera;
         player::Player m_player;

--- a/src/flint/app.h
+++ b/src/flint/app.h
@@ -12,6 +12,7 @@
 #include "graphics/debug_screen_renderer.h"
 #include "graphics/inventory_ui_renderer.h"
 #include "player.h"
+#include "game_state.h"
 
 namespace flint
 {
@@ -28,6 +29,8 @@ namespace flint
         void render();
         void update_camera();
         void onResize(int width, int height);
+        void handle_input_event(const SDL_Event &event);
+        void sync_mouse_state();
 
     private:
         // SDL resources
@@ -57,11 +60,11 @@ namespace flint
 
         Camera m_camera;
         player::Player m_player;
+        GameState m_gameState;
 
         // App state
         bool m_running = false;
         bool m_showDebugScreen = false;
-        bool m_showInventory = false;
         int m_windowWidth = 800;
         int m_windowHeight = 600;
         float m_initialFovY = 60.0f;

--- a/src/flint/game_state.h
+++ b/src/flint/game_state.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+
+namespace flint
+{
+    // Manages game state and determines which systems should be active
+    class GameState
+    {
+    public:
+        GameState() = default;
+
+        // State queries
+        bool should_process_player_input() const { return !m_inventory_open; }
+        bool should_allow_block_interaction() const { return !m_inventory_open; }
+        bool is_inventory_open() const { return m_inventory_open; }
+        bool should_use_relative_mouse() const { return !m_inventory_open; }
+
+        // State changes
+        void toggle_inventory()
+        {
+            m_inventory_open = !m_inventory_open;
+        }
+
+        void open_inventory()
+        {
+            m_inventory_open = true;
+        }
+
+        void close_inventory()
+        {
+            m_inventory_open = false;
+        }
+
+    private:
+        bool m_inventory_open = false;
+        // Future: add more states like pause menu, crafting, etc.
+    };
+
+} // namespace flint

--- a/src/flint/graphics/debug_screen_renderer.cpp
+++ b/src/flint/graphics/debug_screen_renderer.cpp
@@ -108,24 +108,6 @@ namespace flint::graphics
         ImGui::End();
     }
 
-    void DebugScreenRenderer::begin_frame(const flint::player::Player &player, const flint::World &world)
-    {
-        // Legacy method - manages frame lifecycle
-        ImGui_ImplWGPU_NewFrame();
-        ImGui_ImplSDL3_NewFrame();
-        ImGui::NewFrame();
-
-        render_ui(player, world);
-
-        ImGui::Render();
-    }
-
-    void DebugScreenRenderer::render(WGPURenderPassEncoder renderPass)
-    {
-        // Render ImGui
-        ImGui_ImplWGPU_RenderDrawData(ImGui::GetDrawData(), renderPass);
-    }
-
     void DebugScreenRenderer::cleanup()
     {
         std::cout << "Cleaning up debug screen renderer..." << std::endl;

--- a/src/flint/graphics/debug_screen_renderer.cpp
+++ b/src/flint/graphics/debug_screen_renderer.cpp
@@ -52,13 +52,8 @@ namespace flint::graphics
         ImGui_ImplSDL3_ProcessEvent(&event);
     }
 
-    void DebugScreenRenderer::begin_frame(const flint::player::Player &player, const flint::World &world)
+    void DebugScreenRenderer::render_ui(const flint::player::Player &player, const flint::World &world)
     {
-        // Start ImGui frame
-        ImGui_ImplWGPU_NewFrame();
-        ImGui_ImplSDL3_NewFrame();
-        ImGui::NewFrame();
-
         // Create a simple text overlay (like Minecraft HUD)
         // Position in top-left corner with no window decorations
         ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Always);
@@ -111,8 +106,17 @@ namespace flint::graphics
         }
 
         ImGui::End();
+    }
 
-        // Finalize ImGui frame
+    void DebugScreenRenderer::begin_frame(const flint::player::Player &player, const flint::World &world)
+    {
+        // Legacy method - manages frame lifecycle
+        ImGui_ImplWGPU_NewFrame();
+        ImGui_ImplSDL3_NewFrame();
+        ImGui::NewFrame();
+
+        render_ui(player, world);
+
         ImGui::Render();
     }
 

--- a/src/flint/graphics/debug_screen_renderer.cpp
+++ b/src/flint/graphics/debug_screen_renderer.cpp
@@ -47,11 +47,6 @@ namespace flint::graphics
         std::cout << "Debug screen renderer initialized." << std::endl;
     }
 
-    void DebugScreenRenderer::process_event(const SDL_Event &event)
-    {
-        ImGui_ImplSDL3_ProcessEvent(&event);
-    }
-
     void DebugScreenRenderer::render_ui(const flint::player::Player &player, const flint::World &world)
     {
         // Create a simple text overlay (like Minecraft HUD)

--- a/src/flint/graphics/debug_screen_renderer.h
+++ b/src/flint/graphics/debug_screen_renderer.h
@@ -23,14 +23,10 @@ namespace flint::graphics
 
         void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
         void process_event(const SDL_Event &event);
+        void cleanup();
 
         // Creates ImGui windows (does NOT manage frame lifecycle)
         void render_ui(const flint::player::Player &player, const flint::World &world);
-
-        // Legacy method - use render_ui() instead
-        void begin_frame(const flint::player::Player &player, const flint::World &world);
-        void render(WGPURenderPassEncoder renderPass);
-        void cleanup();
 
     private:
         SDL_Window *m_window = nullptr;

--- a/src/flint/graphics/debug_screen_renderer.h
+++ b/src/flint/graphics/debug_screen_renderer.h
@@ -23,6 +23,11 @@ namespace flint::graphics
 
         void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
         void process_event(const SDL_Event &event);
+
+        // Creates ImGui windows (does NOT manage frame lifecycle)
+        void render_ui(const flint::player::Player &player, const flint::World &world);
+
+        // Legacy method - use render_ui() instead
         void begin_frame(const flint::player::Player &player, const flint::World &world);
         void render(WGPURenderPassEncoder renderPass);
         void cleanup();

--- a/src/flint/graphics/debug_screen_renderer.h
+++ b/src/flint/graphics/debug_screen_renderer.h
@@ -22,7 +22,6 @@ namespace flint::graphics
         ~DebugScreenRenderer();
 
         void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
-        void process_event(const SDL_Event &event);
         void cleanup();
 
         // Creates ImGui windows (does NOT manage frame lifecycle)

--- a/src/flint/graphics/inventory_ui_renderer.cpp
+++ b/src/flint/graphics/inventory_ui_renderer.cpp
@@ -1,0 +1,145 @@
+#include "inventory_ui_renderer.h"
+#include "imgui.h"
+#include "imgui_impl_sdl3.h"
+#include "imgui_impl_wgpu.h"
+
+namespace flint::graphics
+{
+
+void InventoryUIRenderer::init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat)
+{
+    m_window = window;
+    m_device = device;
+    m_initialized = true;
+}
+
+void InventoryUIRenderer::cleanup()
+{
+    // ImGui context is shared with debug screen, so we don't destroy it here
+    m_initialized = false;
+}
+
+void InventoryUIRenderer::process_event(const SDL_Event &event)
+{
+    // ImGui events are handled by debug screen renderer
+}
+
+void InventoryUIRenderer::begin_frame(int windowWidth, int windowHeight)
+{
+    if (!m_initialized)
+        return;
+
+    // NOTE: This method creates ImGui windows but doesn't call NewFrame/Render
+    // Those are handled in the app's render loop to avoid conflicts with debug screen
+
+    // Calculate dimensions
+    const float inventoryCols = 9.0f;
+    const float inventoryRows = 3.0f;
+    const float hotbarCols = 9.0f;
+    const float hotbarRows = 1.0f;
+
+    const float slotTotalSize = SLOT_SIZE + SLOT_PADDING;
+    const float inventoryWidth = inventoryCols * slotTotalSize + SLOT_PADDING;
+    const float inventoryHeight = inventoryRows * slotTotalSize + SLOT_PADDING;
+    const float hotbarWidth = hotbarCols * slotTotalSize + SLOT_PADDING;
+    const float hotbarHeight = hotbarRows * slotTotalSize + SLOT_PADDING;
+
+    const float totalHeight = inventoryHeight + GRID_SPACING + hotbarHeight;
+
+    // Center position
+    const float centerX = windowWidth / 2.0f;
+    const float centerY = windowHeight / 2.0f;
+    const float startX = centerX - inventoryWidth / 2.0f;
+    const float startY = centerY - totalHeight / 2.0f;
+
+    // Render dimmed background
+    render_dimmed_background(windowWidth, windowHeight);
+
+    // Render inventory grid (3x9)
+    ImGui::SetNextWindowPos(ImVec2(startX, startY), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(inventoryWidth, inventoryHeight), ImGuiCond_Always);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.2f, 0.2f, 0.2f, 0.95f));
+    ImGui::Begin("Inventory", nullptr,
+                 ImGuiWindowFlags_NoTitleBar |
+                 ImGuiWindowFlags_NoResize |
+                 ImGuiWindowFlags_NoMove |
+                 ImGuiWindowFlags_NoCollapse);
+
+    render_inventory_grid(0, 0, 9, 3, "Inventory");
+
+    ImGui::End();
+    ImGui::PopStyleColor();
+
+    // Render hotbar grid (1x9)
+    const float hotbarStartY = startY + inventoryHeight + GRID_SPACING;
+    ImGui::SetNextWindowPos(ImVec2(startX, hotbarStartY), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(hotbarWidth, hotbarHeight), ImGuiCond_Always);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.2f, 0.2f, 0.2f, 0.95f));
+    ImGui::Begin("Hotbar", nullptr,
+                 ImGuiWindowFlags_NoTitleBar |
+                 ImGuiWindowFlags_NoResize |
+                 ImGuiWindowFlags_NoMove |
+                 ImGuiWindowFlags_NoCollapse);
+
+    render_inventory_grid(0, 0, 9, 1, "Hotbar");
+
+    ImGui::End();
+    ImGui::PopStyleColor();
+}
+
+void InventoryUIRenderer::render(WGPURenderPassEncoder renderPass)
+{
+    // Rendering is handled by ImGui_ImplWGPU_RenderDrawData in the main render loop
+    // This function is here for consistency with other renderers
+}
+
+void InventoryUIRenderer::render_dimmed_background(int windowWidth, int windowHeight)
+{
+    // Create a fullscreen dimmed overlay
+    ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2((float)windowWidth, (float)windowHeight), ImGuiCond_Always);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.6f));
+    ImGui::Begin("DimmedBackground", nullptr,
+                 ImGuiWindowFlags_NoTitleBar |
+                 ImGuiWindowFlags_NoResize |
+                 ImGuiWindowFlags_NoMove |
+                 ImGuiWindowFlags_NoCollapse |
+                 ImGuiWindowFlags_NoInputs |
+                 ImGuiWindowFlags_NoScrollbar |
+                 ImGuiWindowFlags_NoBringToFrontOnFocus);
+    ImGui::End();
+    ImGui::PopStyleColor();
+}
+
+void InventoryUIRenderer::render_inventory_grid(int startX, int startY, int cols, int rows, const char *label)
+{
+    ImDrawList *draw_list = ImGui::GetWindowDrawList();
+    ImVec2 window_pos = ImGui::GetWindowPos();
+
+    const float slotTotalSize = SLOT_SIZE + SLOT_PADDING;
+
+    for (int row = 0; row < rows; ++row)
+    {
+        for (int col = 0; col < cols; ++col)
+        {
+            float x = window_pos.x + startX + SLOT_PADDING + col * slotTotalSize;
+            float y = window_pos.y + startY + SLOT_PADDING + row * slotTotalSize;
+
+            ImVec2 slot_min(x, y);
+            ImVec2 slot_max(x + SLOT_SIZE, y + SLOT_SIZE);
+
+            // Draw slot background
+            draw_list->AddRectFilled(slot_min, slot_max, IM_COL32(60, 60, 60, 255));
+
+            // Draw slot border
+            draw_list->AddRect(slot_min, slot_max, IM_COL32(100, 100, 100, 255), 0.0f, 0, 2.0f);
+
+            // Optional: Draw slot number for debugging
+            // int slot_index = row * cols + col;
+            // ImVec2 text_pos(x + SLOT_SIZE / 2.0f - 5.0f, y + SLOT_SIZE / 2.0f - 7.0f);
+            // draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), std::to_string(slot_index).c_str());
+        }
+    }
+}
+
+} // namespace flint::graphics

--- a/src/flint/graphics/inventory_ui_renderer.cpp
+++ b/src/flint/graphics/inventory_ui_renderer.cpp
@@ -24,13 +24,10 @@ void InventoryUIRenderer::process_event(const SDL_Event &event)
     // ImGui events are handled by debug screen renderer
 }
 
-void InventoryUIRenderer::begin_frame(int windowWidth, int windowHeight)
+void InventoryUIRenderer::render_ui(int windowWidth, int windowHeight)
 {
     if (!m_initialized)
         return;
-
-    // NOTE: This method creates ImGui windows but doesn't call NewFrame/Render
-    // Those are handled in the app's render loop to avoid conflicts with debug screen
 
     // Calculate dimensions
     const float inventoryCols = 9.0f;
@@ -85,6 +82,13 @@ void InventoryUIRenderer::begin_frame(int windowWidth, int windowHeight)
 
     ImGui::End();
     ImGui::PopStyleColor();
+}
+
+void InventoryUIRenderer::begin_frame(int windowWidth, int windowHeight)
+{
+    // Legacy method - just calls render_ui
+    // Frame lifecycle should be managed externally
+    render_ui(windowWidth, windowHeight);
 }
 
 void InventoryUIRenderer::render(WGPURenderPassEncoder renderPass)

--- a/src/flint/graphics/inventory_ui_renderer.cpp
+++ b/src/flint/graphics/inventory_ui_renderer.cpp
@@ -84,19 +84,6 @@ void InventoryUIRenderer::render_ui(int windowWidth, int windowHeight)
     ImGui::PopStyleColor();
 }
 
-void InventoryUIRenderer::begin_frame(int windowWidth, int windowHeight)
-{
-    // Legacy method - just calls render_ui
-    // Frame lifecycle should be managed externally
-    render_ui(windowWidth, windowHeight);
-}
-
-void InventoryUIRenderer::render(WGPURenderPassEncoder renderPass)
-{
-    // Rendering is handled by ImGui_ImplWGPU_RenderDrawData in the main render loop
-    // This function is here for consistency with other renderers
-}
-
 void InventoryUIRenderer::render_dimmed_background(int windowWidth, int windowHeight)
 {
     // Create a fullscreen dimmed overlay

--- a/src/flint/graphics/inventory_ui_renderer.cpp
+++ b/src/flint/graphics/inventory_ui_renderer.cpp
@@ -15,13 +15,7 @@ void InventoryUIRenderer::init(SDL_Window *window, WGPUDevice device, WGPUTextur
 
 void InventoryUIRenderer::cleanup()
 {
-    // ImGui context is shared with debug screen, so we don't destroy it here
     m_initialized = false;
-}
-
-void InventoryUIRenderer::process_event(const SDL_Event &event)
-{
-    // ImGui events are handled by debug screen renderer
 }
 
 void InventoryUIRenderer::render_ui(int windowWidth, int windowHeight)

--- a/src/flint/graphics/inventory_ui_renderer.h
+++ b/src/flint/graphics/inventory_ui_renderer.h
@@ -14,7 +14,6 @@ public:
 
     void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
     void cleanup();
-    void process_event(const SDL_Event &event);
 
     // Creates ImGui windows (does NOT manage frame lifecycle)
     void render_ui(int windowWidth, int windowHeight);

--- a/src/flint/graphics/inventory_ui_renderer.h
+++ b/src/flint/graphics/inventory_ui_renderer.h
@@ -19,10 +19,6 @@ public:
     // Creates ImGui windows (does NOT manage frame lifecycle)
     void render_ui(int windowWidth, int windowHeight);
 
-    // Legacy method - use render_ui() instead
-    void begin_frame(int windowWidth, int windowHeight);
-    void render(WGPURenderPassEncoder renderPass);
-
 private:
     void render_inventory_grid(int startX, int startY, int cols, int rows, const char *label);
     void render_dimmed_background(int windowWidth, int windowHeight);

--- a/src/flint/graphics/inventory_ui_renderer.h
+++ b/src/flint/graphics/inventory_ui_renderer.h
@@ -15,6 +15,11 @@ public:
     void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
     void cleanup();
     void process_event(const SDL_Event &event);
+
+    // Creates ImGui windows (does NOT manage frame lifecycle)
+    void render_ui(int windowWidth, int windowHeight);
+
+    // Legacy method - use render_ui() instead
     void begin_frame(int windowWidth, int windowHeight);
     void render(WGPURenderPassEncoder renderPass);
 

--- a/src/flint/graphics/inventory_ui_renderer.h
+++ b/src/flint/graphics/inventory_ui_renderer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <webgpu/webgpu.h>
+
+namespace flint::graphics
+{
+
+class InventoryUIRenderer
+{
+public:
+    InventoryUIRenderer() = default;
+    ~InventoryUIRenderer() = default;
+
+    void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
+    void cleanup();
+    void process_event(const SDL_Event &event);
+    void begin_frame(int windowWidth, int windowHeight);
+    void render(WGPURenderPassEncoder renderPass);
+
+private:
+    void render_inventory_grid(int startX, int startY, int cols, int rows, const char *label);
+    void render_dimmed_background(int windowWidth, int windowHeight);
+
+    SDL_Window *m_window = nullptr;
+    WGPUDevice m_device = nullptr;
+    bool m_initialized = false;
+
+    // UI dimensions
+    static constexpr float SLOT_SIZE = 50.0f;
+    static constexpr float SLOT_PADDING = 5.0f;
+    static constexpr float GRID_SPACING = 20.0f;
+};
+
+} // namespace flint::graphics

--- a/src/flint/ui/ui_manager.cpp
+++ b/src/flint/ui/ui_manager.cpp
@@ -1,0 +1,79 @@
+#include "ui_manager.h"
+#include <imgui.h>
+#include <imgui_impl_sdl3.h>
+#include <imgui_impl_wgpu.h>
+
+namespace flint::ui
+{
+
+void UIManager::init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat)
+{
+    // Initialize ImGui context (shared by all UI elements)
+    m_debugScreenRenderer.init(window, device, surfaceFormat);
+    m_inventoryUIRenderer.init(window, device, surfaceFormat);
+
+    m_initialized = true;
+}
+
+void UIManager::cleanup()
+{
+    m_inventoryUIRenderer.cleanup();
+    m_debugScreenRenderer.cleanup();
+    m_initialized = false;
+}
+
+void UIManager::process_event(const SDL_Event &event)
+{
+    // ImGui event processing (shared)
+    m_debugScreenRenderer.process_event(event);
+}
+
+void UIManager::render(
+    bool showDebugScreen,
+    bool showInventory,
+    const player::Player &player,
+    const World &world,
+    int windowWidth,
+    int windowHeight
+)
+{
+    if (!m_initialized)
+        return;
+
+    bool needsImGui = showDebugScreen || showInventory;
+    if (!needsImGui)
+    {
+        m_hasActiveFrame = false;
+        return;
+    }
+
+    // Start ImGui frame (ONCE for all UI elements)
+    ImGui_ImplWGPU_NewFrame();
+    ImGui_ImplSDL3_NewFrame();
+    ImGui::NewFrame();
+
+    // Render all active UI elements
+    if (showDebugScreen)
+    {
+        m_debugScreenRenderer.render_ui(player, world);
+    }
+
+    if (showInventory)
+    {
+        m_inventoryUIRenderer.render_ui(windowWidth, windowHeight);
+    }
+
+    // Finalize ImGui frame (ONCE for all UI elements)
+    ImGui::Render();
+    m_hasActiveFrame = true;
+}
+
+void UIManager::render_to_pass(WGPURenderPassEncoder renderPass)
+{
+    if (m_hasActiveFrame)
+    {
+        ImGui_ImplWGPU_RenderDrawData(ImGui::GetDrawData(), renderPass);
+    }
+}
+
+} // namespace flint::ui

--- a/src/flint/ui/ui_manager.cpp
+++ b/src/flint/ui/ui_manager.cpp
@@ -24,8 +24,7 @@ void UIManager::cleanup()
 
 void UIManager::process_event(const SDL_Event &event)
 {
-    // ImGui event processing (shared)
-    m_debugScreenRenderer.process_event(event);
+    ImGui_ImplSDL3_ProcessEvent(&event);
 }
 
 void UIManager::render(

--- a/src/flint/ui/ui_manager.h
+++ b/src/flint/ui/ui_manager.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <webgpu/webgpu.h>
+#include "../graphics/debug_screen_renderer.h"
+#include "../graphics/inventory_ui_renderer.h"
+#include "../player.h"
+#include "../world.h"
+
+namespace flint::ui
+{
+    // Centralized UI manager that owns all UI renderers and manages ImGui lifecycle
+    class UIManager
+    {
+    public:
+        UIManager() = default;
+        ~UIManager() = default;
+
+        void init(SDL_Window *window, WGPUDevice device, WGPUTextureFormat surfaceFormat);
+        void cleanup();
+        void process_event(const SDL_Event &event);
+
+        // Render all active UI elements
+        // This manages the ImGui frame lifecycle internally
+        void render(
+            bool showDebugScreen,
+            bool showInventory,
+            const player::Player &player,
+            const World &world,
+            int windowWidth,
+            int windowHeight
+        );
+
+        // Render the ImGui draw data to the render pass
+        void render_to_pass(WGPURenderPassEncoder renderPass);
+
+    private:
+        graphics::DebugScreenRenderer m_debugScreenRenderer;
+        graphics::InventoryUIRenderer m_inventoryUIRenderer;
+
+        bool m_initialized = false;
+        bool m_hasActiveFrame = false;
+    };
+
+} // namespace flint::ui


### PR DESCRIPTION
- Created InventoryUIRenderer class for rendering inventory interface
- Added 3x9 inventory grid and 1x9 hotbar grid using ImGui
- Implemented dimmed background overlay when inventory is open
- Added 'E' key handling to toggle inventory visibility
- Integrated ImGui frame management to support multiple UI elements
- Empty inventory slots rendered with gray background and borders

The inventory UI is displayed centered on screen when pressing 'E'. The UI consists of two separate windows:
1. Main inventory: 3 rows x 9 columns grid
2. Hotbar: 1 row x 9 columns grid (below main inventory)

All UI elements share the same ImGui frame for proper rendering.